### PR TITLE
compat: update TreeData for anndata 0.13.x API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,14 @@ and this project adheres to [Semantic Versioning][].
 
 ### Changed
 
+- `dtype` parameter in `TreeData.__init__` is now deprecated; passing it raises a `FutureWarning` and has no effect, matching anndata's removal of this argument
+- `obsm`, `varm`, `layers`, `raw`, `shape`, `filename`, `filemode`, `asview`, and related parameters in `TreeData.__init__` are now keyword-only, matching the anndata 0.13.x API
+
 ### Fixed
+
+- Fixed compatibility with anndata 0.13.x: removed `dtype` from internal `_init_as_actual` call, which was removed from AnnData in 0.13.x
+- Fixed compatibility with anndata 0.13.x "Unify X and layers" change: `layers.copy()` and `dict(layers)` no longer include the internal `None` key (used to store X) in `_mutated_copy` and write routines
+- Fixed repr incorrectly showing `layers: None` when anndata 0.13.x stores X as `layers[None]`
 
 ## [0.2.4] - 2025-11-05
 

--- a/src/treedata/_core/treedata.py
+++ b/src/treedata/_core/treedata.py
@@ -58,6 +58,9 @@ class TreeData(ad.AnnData):
         Key-indexed :class:`~networkx.DiGraph` trees leaf nodes in the variables axis.
     layers
         Key-indexed multi-dimensional arrays aligned to dimensions of `X`.
+    dtype
+        .. deprecated::
+            The dtype argument is deprecated and will be removed in a future version.
     shape
         Shape tuple (#observations, #variables). Can only be provided if `X` is `None`.
     filename
@@ -81,15 +84,16 @@ class TreeData(ad.AnnData):
 
     def __init__(
         self,
-        X: np.ndarray | sparse.spmatrix | pd.DataFrame | None = None,
+        X: np.ndarray | sparse.spmatrix | sparse.sparray | pd.DataFrame | None = None,
         obs: pd.DataFrame | Mapping[str, Iterable[Any]] | None = None,
         var: pd.DataFrame | Mapping[str, Iterable[Any]] | None = None,
         uns: Mapping[str, Any] | None = None,
+        *,
         obsm: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
         obst: Mapping[str, nx.DiGraph] | None = None,
         varm: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
         vart: Mapping[str, nx.DiGraph] | None = None,
-        layers: Mapping[str, np.ndarray | sparse.spmatrix] | None = None,
+        layers: Mapping[str, np.ndarray | sparse.spmatrix | sparse.sparray] | None = None,
         raw: Mapping[str, Any] | None = None,
         dtype: np.dtype | type | str | None = None,
         shape: tuple[int, int] | None = None,
@@ -99,12 +103,17 @@ class TreeData(ad.AnnData):
         label: str | None = "tree",
         alignment: Literal["leaves", "nodes", "subset"] = "leaves",
         allow_overlap: bool = True,
-        *,
         obsp: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
         varp: np.ndarray | Mapping[str, Sequence[Any]] | None = None,
         oidx: Index1D | None = None,
         vidx: Index1D | None = None,
     ):
+        if dtype is not None:
+            warnings.warn(
+                "The dtype argument is deprecated and will be removed in a future version.",
+                FutureWarning,
+                stacklevel=2,
+            )
         if asview:
             if not isinstance(X, TreeData):
                 raise ValueError("If asview is True, X has to be an TreeData object")
@@ -123,7 +132,6 @@ class TreeData(ad.AnnData):
                 vart=vart,
                 raw=raw,
                 layers=layers,
-                dtype=dtype,
                 shape=shape,
                 filename=filename,
                 filemode=filemode,
@@ -146,7 +154,6 @@ class TreeData(ad.AnnData):
         vart=None,
         raw=None,
         layers=None,
-        dtype=None,
         shape=None,
         filename=None,
         filemode=None,
@@ -171,7 +178,6 @@ class TreeData(ad.AnnData):
             obsp=obsp,
             raw=raw,
             layers=layers,
-            dtype=dtype,
             shape=shape,
             filename=filename,
             filemode=filemode,

--- a/src/treedata/_core/treedata.py
+++ b/src/treedata/_core/treedata.py
@@ -423,7 +423,10 @@ class TreeData(ad.AnnData):
             if key in kwargs:
                 new[key] = kwargs[key]
             else:
-                new[key] = getattr(self, key).copy()
+                val = getattr(self, key).copy()
+                if key == "layers":
+                    val.pop(None, None)  # X is passed via X=; don't duplicate in layers
+                new[key] = val
         if "X" in kwargs:
             new["X"] = kwargs["X"]
         elif self._has_X():

--- a/src/treedata/_core/treedata.py
+++ b/src/treedata/_core/treedata.py
@@ -383,6 +383,8 @@ class TreeData(ad.AnnData):
         descr = f"TreeData object with n_obs × n_vars = {n_obs} × {n_vars}{backed_at}"
         for attr in ["obs", "var", "uns", "obsm", "varm", "layers", "obsp", "varp", "obst", "vart"]:
             keys = getattr(self, attr).keys()
+            if attr == "layers":
+                keys = [k for k in keys if k is not None]
             if len(keys) > 0:
                 descr += f"\n    {attr}: {str(list(keys))[1:-1]}"
         return descr

--- a/src/treedata/_core/write.py
+++ b/src/treedata/_core/write.py
@@ -80,8 +80,10 @@ def _write_tdata(f, tdata, filename, chunks=None, **kwargs) -> None:
     for key in ["obs", "var", "label", "allow_overlap", "alignment"]:
         _write_elem(f, key, getattr(tdata, key), dataset_kwargs=kwargs)
     # Write group elements
-    for key in ["obsm", "varm", "obsp", "varp", "layers", "uns"]:
+    for key in ["obsm", "varm", "obsp", "varp", "uns"]:
         _write_elem(f, key, dict(getattr(tdata, key)), dataset_kwargs=kwargs)
+    # Write layers without X (X is written separately above; None key added in anndata 0.13.x)
+    _write_elem(f, "layers", {k: v for k, v in tdata.layers.items() if k is not None}, dataset_kwargs=kwargs)
     # Write axis tree elements
     for key in ["obst", "vart"]:
         _write_elem(f, key, _serialize_axis_trees(getattr(tdata, key)), dataset_kwargs=kwargs)


### PR DESCRIPTION
## Summary

- Fixes a `TypeError` with anndata 0.13.x caused by `dtype` being removed from `AnnData._init_as_actual` — removes `dtype=dtype` from the `super()._init_as_actual()` call
- Deprecates `dtype` in `TreeData.__init__` with a `FutureWarning` when passed (matching anndata's own deprecation trajectory)
- Makes `obsm`, `varm`, `layers`, `raw`, `shape`, `filename`, `filemode`, `asview`, `label`, `alignment`, `allow_overlap`, `obsp`, `varp`, `oidx`, `vidx` keyword-only in `__init__`, aligning with anndata 0.13.x's API
- Adds `sparse.sparray` to `X` and `layers` type annotations for scipy 1.8+ compatibility

## Test plan

- [x] All 50 existing tests pass against anndata 0.12.16 (`python -m pytest tests/ -v`)
- [x] `dtype` deprecation warning fires correctly when passed
- [x] `dtype=None` (default) is silent
- [ ] Verify against anndata 0.13.x once available for Python 3.11 (dev version requires Python ≥3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)